### PR TITLE
feat: add reusable EmptyState component

### DIFF
--- a/src/components/common/EmptyState.jsx
+++ b/src/components/common/EmptyState.jsx
@@ -1,0 +1,60 @@
+const EmptyState = ({
+  icon = "📭",
+  title = "Nothing here yet",
+  message = "No data to display at the moment.",
+  actionLabel,
+  onAction,
+  className = "",
+}) => {
+  return (
+    <div className={`empty-state ${className}`} style={styles.container}>
+      <div style={styles.icon}>{icon}</div>
+      <h3 style={styles.title}>{title}</h3>
+      <p style={styles.message}>{message}</p>
+      {actionLabel && onAction && (
+        <button onClick={onAction} style={styles.button}>
+          {actionLabel}
+        </button>
+      )}
+    </div>
+  );
+};
+
+const styles = {
+  container: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: "3rem 1rem",
+    textAlign: "center",
+    minHeight: "200px",
+  },
+  icon: {
+    fontSize: "3rem",
+    marginBottom: "1rem",
+  },
+  title: {
+    margin: "0 0 0.5rem",
+    fontSize: "1.25rem",
+    fontWeight: 600,
+    color: "#1a1a2e",
+  },
+  message: {
+    margin: "0 0 1.5rem",
+    color: "#6b7280",
+    maxWidth: "400px",
+  },
+  button: {
+    padding: "0.5rem 1.5rem",
+    backgroundColor: "#4f46e5",
+    color: "#fff",
+    border: "none",
+    borderRadius: "0.375rem",
+    cursor: "pointer",
+    fontSize: "0.875rem",
+    fontWeight: 500,
+  },
+};
+
+export default EmptyState;

--- a/src/components/common/EmptyState.jsx
+++ b/src/components/common/EmptyState.jsx
@@ -12,7 +12,7 @@ const EmptyState = ({
       <h3 style={styles.title}>{title}</h3>
       <p style={styles.message}>{message}</p>
       {actionLabel && onAction && (
-        <button onClick={onAction} style={styles.button}>
+        <button type="button" onClick={onAction} style={styles.button}>
           {actionLabel}
         </button>
       )}

--- a/src/components/common/EmptyState.jsx
+++ b/src/components/common/EmptyState.jsx
@@ -7,7 +7,7 @@ const EmptyState = ({
   className = "",
 }) => {
   return (
-    <div className={`empty-state ${className}`} style={styles.container}>
+    <div className={className} style={styles.container}>
       <div style={styles.icon}>{icon}</div>
       <h3 style={styles.title}>{title}</h3>
       <p style={styles.message}>{message}</p>


### PR DESCRIPTION
## Summary
Create `EmptyState` component in `src/components/common/EmptyState.jsx` for displaying friendly empty states across all pages.

## Props
| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `icon` | string | `"📭"` | Emoji or icon to display |
| `title` | string | `"Nothing here yet"` | Main heading |
| `message` | string | `"No data to display..."` | Description text |
| `actionLabel` | string | — | Button label (optional) |
| `onAction` | function | — | Button click handler (optional) |

## Test plan
- [ ] Import and render `<EmptyState />` with default props
- [ ] Render with custom icon, title, message
- [ ] Render with action button and verify click handler
- [ ] Verify centered layout on desktop and mobile

Closes #13